### PR TITLE
socket is not closed after SwiftyPing deallocated.

### DIFF
--- a/Sources/SwiftyPing/SwiftyPing.swift
+++ b/Sources/SwiftyPing/SwiftyPing.swift
@@ -301,7 +301,10 @@ public class SwiftyPing: NSObject {
             CFRunLoopSourceInvalidate(socketSource)
             socketSource = nil
         }
-        socket = nil
+        if socket != nil {
+            CFSocketInvalidate(socket)
+            socket = nil
+        }
         timeoutTimer?.invalidate()
         timeoutTimer = nil
     }


### PR DESCRIPTION
socket is not closed after SwiftyPing deallocated.

Reproduce method:
1. create many SwiftyPing objects, call  startPinging(), while task complete in the observer call back, call stopPinging()
2. make sure the SwiftyPing is deallocated.
3. use  command "lsof -np < pid > | grep ICMP", we can see that many socket is still open.