### PR TITLE
Fixes Socket Info Memory Leak - Issue #27

### DIFF
--- a/Sources/SwiftyPing/SwiftyPing.swift
+++ b/Sources/SwiftyPing/SwiftyPing.swift
@@ -272,7 +272,7 @@ public class SwiftyPing: NSObject {
                 let cfdata = Unmanaged<CFData>.fromOpaque(data).takeUnretainedValue()
                 ping?.socket(socket: socket, didReadData: cfdata as Data)
             }
-            
+            _ = Unmanaged<SocketInfo>.fromOpaque(info).takeRetainedValue()
         }, &context)
         
         // Disable SIGPIPE, see issue #15 on GitHub.


### PR DESCRIPTION
I had a bit of time today to look into this. This one-liner seems to fix the memory leak related to SocketInfo by balancing out the retain on CFSocketContext