### PR TITLE
Fix PingDelegate error

### DIFF
--- a/Sources/SwiftyPing/SwiftyPing.swift
+++ b/Sources/SwiftyPing/SwiftyPing.swift
@@ -17,7 +17,7 @@ public typealias Observer = ((_ response: PingResponse) -> Void)
 public typealias FinishedCallback = ((_ result: PingResult) -> Void)
 
 /// Represents a ping delegate.
-public protocol PingDelegate {
+public protocol PingDelegate: AnyObject {
     /// Called when a ping response is received.
     /// - Parameter response: A `PingResponse` object representing the echo reply.
     func didReceive(response: PingResponse)


### PR DESCRIPTION
Fixes a compile error: `'weak' must not be applied to non-class-bound 'PingDelegate'; consider adding a protocol conformance that has a class bound`