### PR TITLE
Adding !targetEnvironment(macCatalyst) tag

### DIFF
--- a/Sources/SwiftyPing/SwiftyPing.swift
+++ b/Sources/SwiftyPing/SwiftyPing.swift
@@ -213,14 +213,14 @@ public class SwiftyPing: NSObject {
         super.init()
         try createSocket()
         
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         if configuration.handleBackgroundTransitions {
             addAppStateNotifications()
         }
         #endif
     }
     
-    #if os(iOS)
+    #if os(iOS) && !targetEnvironment(macCatalyst)
     /// Adds notification observers for iOS app state changes.
     private func addAppStateNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(didEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)


### PR DESCRIPTION
Removing background halting of pinging when using Mac Catalyst. Kind of addresses https://github.com/samiyr/SwiftyPing/issues/43